### PR TITLE
remove /jobs from history server url

### DIFF
--- a/frontend/src/components/AppActions.tsx
+++ b/frontend/src/components/AppActions.tsx
@@ -23,7 +23,7 @@ const AppActions: React.FC<Props> = ({app, onDelete}) => {
           aria-label="History"
           as={ExLink}
           target="_blank"
-          href={`${conf.sparkHistoryServerUrl}/history/${app.appId}/jobs`}
+          href={`${conf.sparkHistoryServerUrl}/history/${app.appId}`}
         />
       )}
       {!!conf?.externalLogsUrlTemplate && !!app.appId && (


### PR DESCRIPTION
Fix issue #35 

remove `/jobs` from history server link so the history server will redirect to `{last_attempt}/jobs` on YARN