### PR TITLE
Remove OS specific file path separator

### DIFF
--- a/server/src/test/groovy/com/exacaster/lighter/backend/yarn/YarnBackendTest.groovy
+++ b/server/src/test/groovy/com/exacaster/lighter/backend/yarn/YarnBackendTest.groovy
@@ -81,7 +81,7 @@ class YarnBackendTest extends Specification {
         def resource = backend.getSessionJobResources()
 
         then:
-        resource.endsWith("/shell_wrapper.py")
+        resource.endsWith("shell_wrapper.py")
     }
 
     def "kills application"() {


### PR DESCRIPTION
Removed `/`  file path separator for windows compatibility, with the `/` the test fails on windows