### PR TITLE
Refactor k8s submit props, fix image overvrite

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,7 +31,6 @@ Example of `LIGHTER_BATCH_DEFAULT_CONF`: `{"spark.kubernetes.driverEnv.TEST1":"t
 | LIGHTER_KUBERNETES_NAMESPACE       | Kubernetes namespace                                 | spark                                          |
 | LIGHTER_KUBERNETES_MAX_LOG_SIZE    | Max lines of log to store on DB                      | 500                                            |
 | LIGHTER_KUBERNETES_SERVICE_ACCOUNT | Kubernetes service account                           | spark                                          |
-| LIGHTER_KUBERNETES_CONTAINER_IMAGE | Container image to use for Spark driver and executor | TODO                                           |
 
 
 ## YARN configuration

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -111,8 +111,6 @@ spec:
                             value: https://address_to_spark_history/spark-history
                         -   name: LIGHTER_MAX_RUNNING_JOBS
                             value: "15"
-                        -   name: LIGHTER_KUBERNETES_CONTAINER_IMAGE
-                            value: "ghcr.io/exacaster/spark:latest"
             serviceAccountName: spark
 ```
 

--- a/server/src/main/java/com/exacaster/lighter/backend/kubernetes/KubernetesProperties.java
+++ b/server/src/main/java/com/exacaster/lighter/backend/kubernetes/KubernetesProperties.java
@@ -1,13 +1,8 @@
 package com.exacaster.lighter.backend.kubernetes;
 
-import static io.micronaut.core.convert.format.MapFormat.MapTransformation.FLAT;
-import static io.micronaut.core.naming.conventions.StringConvention.RAW;
-
 import io.micronaut.context.annotation.ConfigurationInject;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.context.annotation.Requires;
-import io.micronaut.core.convert.format.MapFormat;
-import java.util.Map;
 import java.util.StringJoiner;
 
 @ConfigurationProperties("lighter.kubernetes")
@@ -17,16 +12,14 @@ public class KubernetesProperties{
     private final String namespace;
     private final Integer maxLogSize;
     private final String master;
-    private final Map<String, String> submitProps;
+    private final String serviceAccount;
 
     @ConfigurationInject
-    public KubernetesProperties(String namespace, Integer maxLogSize, String master,
-            @MapFormat(transformation = FLAT, keyFormat = RAW)
-            Map<String, String> submitProps) {
+    public KubernetesProperties(String namespace, Integer maxLogSize, String master, String serviceAccount) {
         this.namespace = namespace;
         this.maxLogSize = maxLogSize;
         this.master = master;
-        this.submitProps = submitProps;
+        this.serviceAccount = serviceAccount;
     }
 
     public String getNamespace() {
@@ -41,8 +34,8 @@ public class KubernetesProperties{
         return master;
     }
 
-    public Map<String, String> getSubmitProps() {
-        return submitProps;
+    public String getServiceAccount() {
+        return serviceAccount;
     }
 
     @Override
@@ -51,7 +44,7 @@ public class KubernetesProperties{
                 .add("namespace='" + namespace + "'")
                 .add("maxLogSize=" + maxLogSize)
                 .add("master=" + master)
-                .add("submitProps=" + submitProps)
+                .add("serviceAccount=" + serviceAccount)
                 .toString();
     }
 }

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -12,15 +12,7 @@ lighter:
         master: k8s://kubernetes.default.svc.cluster.local:443
         namespace: spark
         service-account: spark
-        container-image: "218320193259.dkr.ecr.eu-central-1.amazonaws.com/hellcat:0.0.2796"
         max-log-size: 500
-        submit-props:
-          "spark.kubernetes.container.image": ${lighter.kubernetes.container-image}
-          "spark.kubernetes.namespace": ${lighter.kubernetes.namespace}
-          "spark.kubernetes.authenticate.driver.serviceAccountName": ${lighter.kubernetes.service-account}
-          "spark.kubernetes.driver.podTemplateFile": "/home/app/k8s/driver_pod_template.yaml"
-          "spark.kubernetes.executor.podTemplateFile": "/home/app/k8s/executor_pod_template.yaml"
-          "spark.hadoop.fs.s3a.fast.upload": "true"
     storage:
         jdbc:
             enabled: true

--- a/server/src/test/groovy/com/exacaster/lighter/test/Factories.groovy
+++ b/server/src/test/groovy/com/exacaster/lighter/test/Factories.groovy
@@ -51,7 +51,7 @@ class Factories {
 
     static kubernetesProperties() {
         new KubernetesProperties("spark", 500, "k8s://kubernetes.default.svc.cluster.local:443",
-                ["spark.kubernetes.namespace": "spark"])
+                "spark")
     }
 
     static appConfiguration() {


### PR DESCRIPTION
@Minutis @hynix 
Removed `LIGHTER_KUBERNETES_CONTAINER_IMAGE`, default image should be managed through `LIGHTER_BATCH_DEFAULT_CONF` if needed.

