### PR TITLE
Do not fail on stderr error

### DIFF
--- a/server/src/main/java/com/exacaster/lighter/application/ApplicationStatusHandler.java
+++ b/server/src/main/java/com/exacaster/lighter/application/ApplicationStatusHandler.java
@@ -51,16 +51,7 @@ public class ApplicationStatusHandler {
     }
 
     public void processApplicationError(Application application, Throwable error) {
-        // Workaround for case when Spark launcher logs
-        // `DEBUG Configuration: Handling deprecation for hive.stats.ndv.error`
-        // on org.apache.spark.launcher.OutputRedirector#redirect() it marks all stdout lines
-        // containing `error` string as Exceptions.
-        if (error.getMessage().contains("hive.stats.ndv.error")) {
-            LOG.debug("Skipping", error);
-            return;
-        }
-
-        LOG.warn("Application {} error occurred", application, error);
+        LOG.warn("Marking application {} failed because of error {}", application.getId(), error.getMessage());
         var appId = backend.getInfo(application).map(ApplicationInfo::getApplicationId)
                 .orElse(null);
         applicationStorage.saveApplication(

--- a/server/src/main/java/com/exacaster/lighter/spark/SparkListener.java
+++ b/server/src/main/java/com/exacaster/lighter/spark/SparkListener.java
@@ -25,8 +25,12 @@ public class SparkListener implements Listener, Waitable {
     public void stateChanged(SparkAppHandle handle) {
         var state = handle.getState();
         LOG.info("State change. AppId: {}, State: {}", handle.getAppId(), state);
-        handle.getError().ifPresent(errorHandler);
-
+        handle.getError().ifPresent((error) -> {
+            LOG.warn("State changed with error: {} ", error.getMessage());
+            if (State.FAILED.equals(state)) {
+                errorHandler.accept(error);
+            }
+        });
         // Disconnect when final or submitted.
         // In case app fails after detach, status will be retrieved by ApplicationStatusHandler.
         if (state != null && (state.isFinal() || State.SUBMITTED.equals(state))) {


### PR DESCRIPTION
Previous workaround #46 din not cover all cases, it turns out Spark launcher redirects many false-positive errors, when submitting applications on Yarn.

With this change, we only handle errors, when application status is reported as FAILED, for other cases I'm keeping warn level logging.

@Minutis 