### PR TITLE
Do not error on empty statements, return empty instead

### DIFF
--- a/server/src/main/resources/shell_wrapper.py
+++ b/server/src/main/resources/shell_wrapper.py
@@ -108,10 +108,12 @@ class CommandHandler:
 
     def exec(self, request):
         try:
-            code = request["code"]
-            self._exec_then_eval(code.rstrip())
+            code = request["code"].rstrip()
+            if code:
+                self._exec_then_eval(code)
+                return {"content": {"text/plain": str(sys.stdout.getvalue()).rstrip()}}
 
-            return {"content": {"text/plain": str(sys.stdout.getvalue()).rstrip()}}
+            return {"content": {"text/plain": ""}}
         except Exception as e:
             log.exception(e)
             return self._error_response(e)

--- a/server/src/test/groovy/com/exacaster/lighter/application/sessions/processors/PythonProcessorTest.groovy
+++ b/server/src/test/groovy/com/exacaster/lighter/application/sessions/processors/PythonProcessorTest.groovy
@@ -106,4 +106,18 @@ class PythonProcessorTest extends Specification {
         result.message == "name 'x' is not defined"
         result.traceback.size() > 0
     }
+
+    def "returns nothing for empty statement"() {
+        when:
+        def result = processor.process("")
+        then:
+        result.content[TEXT_PLAIN] == ""
+    }
+
+    def "returns nothing for new line statement"() {
+        when:
+        def result = processor.process("\n")
+        then:
+        result.content[TEXT_PLAIN] == ""
+    }
 }


### PR DESCRIPTION
In some cases (https://github.com/exacaster/lighter/issues/311#issuecomment-1382750524 - I could not reproduce them) it is possible to submit session statements without any code. 
Error was returned for these kind of statements.

This PR changes this behavior. Now empty response will be returned, when statement is empty

@Minutis 