### PR TITLE
Fix create statement

### DIFF
--- a/server/src/main/java/com/exacaster/lighter/application/sessions/SessionService.java
+++ b/server/src/main/java/com/exacaster/lighter/application/sessions/SessionService.java
@@ -75,7 +75,7 @@ public class SessionService {
     public Optional<Application> fetchOne(String id, boolean liveStatus) {
         return applicationStorage.findApplication(id)
                 .map(app -> {
-                    if (app.getState().isComplete() && liveStatus) {
+                    if (!app.getState().isComplete() && liveStatus) {
                         return backend.getInfo(app)
                                 .map(info -> {
                                     var hasWaiting = statementHandler.hasWaitingStatement(app);

--- a/server/src/main/java/com/exacaster/lighter/application/sessions/SessionService.java
+++ b/server/src/main/java/com/exacaster/lighter/application/sessions/SessionService.java
@@ -30,8 +30,8 @@ public class SessionService {
     private final StatementHandler statementHandler;
 
     public SessionService(ApplicationStorage applicationStorage,
-                          StatementStorage statementStorage, Backend backend,
-                          StatementHandler statementHandler) {
+            StatementStorage statementStorage, Backend backend,
+            StatementHandler statementHandler) {
         this.applicationStorage = applicationStorage;
         this.statementStorage = statementStorage;
         this.backend = backend;

--- a/server/src/main/java/com/exacaster/lighter/application/sessions/StatementCreationResult.java
+++ b/server/src/main/java/com/exacaster/lighter/application/sessions/StatementCreationResult.java
@@ -1,0 +1,50 @@
+package com.exacaster.lighter.application.sessions;
+
+import com.exacaster.lighter.application.ApplicationState;
+
+public interface StatementCreationResult {
+    <T> T map(StatementCreationResultMapper<T> statementCreationResultMapper);
+
+    class StatementCreated implements StatementCreationResult {
+        private final Statement statement;
+
+        public StatementCreated(Statement statement) {
+            this.statement = statement;
+        }
+
+        @Override
+        public <T> T map(StatementCreationResultMapper<T> statementCreationResultMapper) {
+            return statementCreationResultMapper.mapStatementCreated(this.statement);
+        }
+
+        public Statement getStatement() {
+            return statement;
+        }
+    }
+
+    class NoSessionExists implements StatementCreationResult {
+        @Override
+        public <T> T map(StatementCreationResultMapper<T> statementCreationResultMapper) {
+            return statementCreationResultMapper.mapNoSessionExists();
+        }
+    }
+
+    class SessionInInvalidState implements StatementCreationResult {
+        private final ApplicationState invalidState;
+
+        public ApplicationState getInvalidState() {
+            return invalidState;
+        }
+
+        public SessionInInvalidState(ApplicationState invalidState) {
+            this.invalidState = invalidState;
+        }
+
+        @Override
+        public <T> T map(StatementCreationResultMapper<T> statementCreationResultMapper) {
+            return statementCreationResultMapper.mapSessionInInvalidState(this.invalidState);
+        }
+    }
+
+}
+

--- a/server/src/main/java/com/exacaster/lighter/application/sessions/StatementCreationResultMapper.java
+++ b/server/src/main/java/com/exacaster/lighter/application/sessions/StatementCreationResultMapper.java
@@ -1,0 +1,10 @@
+package com.exacaster.lighter.application.sessions;
+
+import com.exacaster.lighter.application.ApplicationState;
+
+public interface StatementCreationResultMapper<T> {
+    T mapStatementCreated(Statement sessionCreated);
+    T mapNoSessionExists();
+    T mapSessionInInvalidState(ApplicationState sessionState);
+}
+

--- a/server/src/main/java/com/exacaster/lighter/rest/MicronautStatementCreationResultToResponseMapper.java
+++ b/server/src/main/java/com/exacaster/lighter/rest/MicronautStatementCreationResultToResponseMapper.java
@@ -1,0 +1,23 @@
+package com.exacaster.lighter.rest;
+
+import com.exacaster.lighter.application.ApplicationState;
+import com.exacaster.lighter.application.sessions.Statement;
+import com.exacaster.lighter.application.sessions.StatementCreationResultMapper;
+import io.micronaut.http.HttpResponse;
+
+public class MicronautStatementCreationResultToResponseMapper implements StatementCreationResultMapper<HttpResponse> {
+    @Override
+    public HttpResponse mapStatementCreated(Statement sessionCreated) {
+        return HttpResponse.created(sessionCreated);
+    }
+
+    @Override
+    public HttpResponse mapNoSessionExists() {
+        return HttpResponse.notFound();
+    }
+
+    @Override
+    public HttpResponse mapSessionInInvalidState(ApplicationState sessionState) {
+        return HttpResponse.badRequest("invalid session state " + sessionState);
+    }
+}

--- a/server/src/main/java/com/exacaster/lighter/rest/SessionController.java
+++ b/server/src/main/java/com/exacaster/lighter/rest/SessionController.java
@@ -2,14 +2,15 @@ package com.exacaster.lighter.rest;
 
 import com.exacaster.lighter.application.Application;
 import com.exacaster.lighter.application.ApplicationList;
+import com.exacaster.lighter.application.SubmitParams;
 import com.exacaster.lighter.application.sessions.SessionService;
 import com.exacaster.lighter.application.sessions.Statement;
 import com.exacaster.lighter.application.sessions.StatementList;
 import com.exacaster.lighter.log.LogService;
 import com.exacaster.lighter.rest.magic.SessionList;
 import com.exacaster.lighter.rest.magic.SparkMagicCompatibility;
-import com.exacaster.lighter.application.SubmitParams;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
@@ -21,11 +22,12 @@ import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.http.annotation.Status;
 import io.micronaut.validation.Validated;
+
+import javax.validation.Valid;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import javax.validation.Valid;
 
 @Validated
 @Controller("/lighter/api/sessions")
@@ -91,9 +93,9 @@ public class SessionController {
     }
 
     @Post("/{id}/statements")
-    @Status(HttpStatus.CREATED)
-    public Statement postStatements(@PathVariable String id, @Valid @Body Statement statement) {
-        return sessionService.createStatement(id, statement);
+    public HttpResponse postStatements(@PathVariable String id, @Valid @Body Statement statement) {
+        MicronautStatementCreationResultToResponseMapper resultToResponseMapper = new MicronautStatementCreationResultToResponseMapper();
+        return sessionService.createStatement(id, statement).map(resultToResponseMapper);
     }
 
     @Get("/{id}/statements")

--- a/server/src/test/groovy/com/exacaster/lighter/application/sessions/CreateStatementTest.groovy
+++ b/server/src/test/groovy/com/exacaster/lighter/application/sessions/CreateStatementTest.groovy
@@ -50,6 +50,25 @@ class CreateStatementTest extends Specification {
         ((StatementCreationResult.SessionInInvalidState)result).getInvalidState() == session.state
     }
 
+    def "on completed session returns SessionInInvalidState"() {
+        given:
+        def statementToCreate = newStatement()
+
+        and: "session is stored with non completed state "
+        def session = newSession(ApplicationState.STARTING)
+        storage.saveApplication(session)
+
+        and: "session 'live' status is completed "
+        backend.getInfo(session) >>  Optional.of( new ApplicationInfo(ApplicationState.ERROR, session.id))
+
+        when: "creating statement"
+        def result = service.createStatement(session.id, statementToCreate)
+
+        then: "returns session in invalid state"
+        result instanceof StatementCreationResult.SessionInInvalidState
+        ((StatementCreationResult.SessionInInvalidState)result).getInvalidState() == ApplicationState.ERROR
+    }
+
     def "on non-completed session returns StatementCreated"() {
         given:
         def statementToCreate = newStatement()

--- a/server/src/test/groovy/com/exacaster/lighter/application/sessions/CreateStatementTest.groovy
+++ b/server/src/test/groovy/com/exacaster/lighter/application/sessions/CreateStatementTest.groovy
@@ -34,8 +34,12 @@ class CreateStatementTest extends Specification {
     def "on killed session returns SessionInInvalidState"() {
         given:
         def params = newStatement()
+
+        and: "session is stored with status killed"
         def session = newSession(ApplicationState.KILLED)
         storage.saveApplication(session)
+
+        and: "session 'live' status is killed"
         backend.getInfo(session) >>  Optional.of( new ApplicationInfo(session.state, session.id))
 
         when: "creating statement"
@@ -49,8 +53,12 @@ class CreateStatementTest extends Specification {
     def "on non-completed session returns StatementCreated"() {
         given:
         def statementToCreate = newStatement()
+
+        and: "session is stored with non completed state "
         def session = newSession(ApplicationState.STARTING)
         storage.saveApplication(session)
+
+        and: "session 'live' status is not completed "
         backend.getInfo(session) >>  Optional.of( new ApplicationInfo(session.state, session.id))
         def statementCreated = statement()
         statementHandler.processStatement(session.id, statementToCreate) >> statementCreated

--- a/server/src/test/groovy/com/exacaster/lighter/application/sessions/CreateStatementTest.groovy
+++ b/server/src/test/groovy/com/exacaster/lighter/application/sessions/CreateStatementTest.groovy
@@ -1,0 +1,66 @@
+package com.exacaster.lighter.application.sessions
+
+import com.exacaster.lighter.application.ApplicationInfo
+import com.exacaster.lighter.application.ApplicationState
+import com.exacaster.lighter.application.sessions.processors.StatementHandler
+import com.exacaster.lighter.backend.Backend
+import com.exacaster.lighter.storage.ApplicationStorage
+import com.exacaster.lighter.storage.StatementStorage
+import com.exacaster.lighter.test.InMemoryStorage
+import spock.lang.Specification
+import spock.lang.Subject
+
+import static com.exacaster.lighter.test.Factories.*
+
+class CreateStatementTest extends Specification {
+    ApplicationStorage storage = new InMemoryStorage()
+    Backend backend = Mock()
+    StatementHandler statementHandler = Mock()
+
+    @Subject
+    SessionService service = new SessionService(storage, Mock(StatementStorage), backend, statementHandler)
+
+    def 'on non existing session id returns NoSessionExists'() {
+        given:
+        def params = newStatement()
+
+        when: "creating statement"
+        def result = service.createStatement("sessionId", params)
+
+        then: "returns no session found"
+        result instanceof StatementCreationResult.NoSessionExists
+    }
+
+    def "on killed session returns SessionInInvalidState"() {
+        given:
+        def params = newStatement()
+        def session = newSession(ApplicationState.KILLED)
+        storage.saveApplication(session)
+        backend.getInfo(session) >>  Optional.of( new ApplicationInfo(session.state, session.id))
+
+        when: "creating statement"
+        def result = service.createStatement(session.id, params)
+
+        then: "returns session in invalid state"
+        result instanceof StatementCreationResult.SessionInInvalidState
+        ((StatementCreationResult.SessionInInvalidState)result).getInvalidState() == session.state
+    }
+
+    def "on non-completed session returns StatementCreated"() {
+        given:
+        def statementToCreate = newStatement()
+        def session = newSession(ApplicationState.STARTING)
+        storage.saveApplication(session)
+        backend.getInfo(session) >>  Optional.of( new ApplicationInfo(session.state, session.id))
+        def statementCreated = statement()
+        statementHandler.processStatement(session.id, statementToCreate) >> statementCreated
+
+        when: "creating statement"
+        def result = service.createStatement(session.id, statementToCreate)
+
+        then: "returns statement created"
+        result instanceof StatementCreationResult.StatementCreated
+        ((StatementCreationResult.StatementCreated)result).getStatement() == statementCreated
+    }
+
+}

--- a/server/src/test/groovy/com/exacaster/lighter/application/sessions/SessionServiceTest.groovy
+++ b/server/src/test/groovy/com/exacaster/lighter/application/sessions/SessionServiceTest.groovy
@@ -1,6 +1,5 @@
 package com.exacaster.lighter.application.sessions
 
-import com.exacaster.lighter.application.ApplicationInfo
 import com.exacaster.lighter.application.ApplicationState
 import com.exacaster.lighter.application.sessions.processors.StatementHandler
 import com.exacaster.lighter.backend.Backend
@@ -11,7 +10,7 @@ import com.exacaster.lighter.test.InMemoryStorage
 import spock.lang.Specification
 import spock.lang.Subject
 
-import static com.exacaster.lighter.test.Factories.*
+import static com.exacaster.lighter.test.Factories.submitParams
 
 class SessionServiceTest extends Specification {
     ApplicationStorage storage = new InMemoryStorage()
@@ -68,48 +67,4 @@ class SessionServiceTest extends Specification {
         then: "returns empty"
         session.isEmpty()
     }
-
-    def "create statement"() {
-        given:
-        def params = newStatement()
-
-        when: "creating statement"
-        def result = service.createStatement("sessionId", params)
-
-        then: "returns no session found"
-        result instanceof StatementCreationResult.NoSessionExists
-    }
-
-    def "create statement2"() {
-        given:
-        def params = newStatement()
-        def session = newSession(ApplicationState.KILLED)
-        storage.saveApplication(session)
-        backend.getInfo(session) >>  Optional.of( new ApplicationInfo(session.state, session.id))
-
-        when: "creating statement"
-        def result = service.createStatement(session.id, params)
-
-        then: "returns session in invalid state"
-        result instanceof StatementCreationResult.SessionInInvalidState
-        ((StatementCreationResult.SessionInInvalidState)result).getInvalidState() == session.state
-    }
-
-    def "create statement3"() {
-        given:
-        def statementToCreate = newStatement()
-        def session = newSession(ApplicationState.STARTING)
-        storage.saveApplication(session)
-        backend.getInfo(session) >>  Optional.of( new ApplicationInfo(session.state, session.id))
-        def statementCreated = statement()
-        statementHandler.processStatement(session.id, statementToCreate) >> statementCreated
-
-        when: "creating statement"
-        def result = service.createStatement(session.id, statementToCreate)
-
-        then: "returns statement created"
-        result instanceof StatementCreationResult.StatementCreated
-        ((StatementCreationResult.StatementCreated)result).getStatement() == statementCreated
-    }
-
 }

--- a/server/src/test/groovy/com/exacaster/lighter/application/sessions/SessionServiceTest.groovy
+++ b/server/src/test/groovy/com/exacaster/lighter/application/sessions/SessionServiceTest.groovy
@@ -1,5 +1,6 @@
 package com.exacaster.lighter.application.sessions
 
+import com.exacaster.lighter.application.ApplicationInfo
 import com.exacaster.lighter.application.ApplicationState
 import com.exacaster.lighter.application.sessions.processors.StatementHandler
 import com.exacaster.lighter.backend.Backend
@@ -10,7 +11,7 @@ import com.exacaster.lighter.test.InMemoryStorage
 import spock.lang.Specification
 import spock.lang.Subject
 
-import static com.exacaster.lighter.test.Factories.submitParams
+import static com.exacaster.lighter.test.Factories.*
 
 class SessionServiceTest extends Specification {
     ApplicationStorage storage = new InMemoryStorage()
@@ -67,4 +68,48 @@ class SessionServiceTest extends Specification {
         then: "returns empty"
         session.isEmpty()
     }
+
+    def "create statement"() {
+        given:
+        def params = newStatement()
+
+        when: "creating statement"
+        def result = service.createStatement("sessionId", params)
+
+        then: "returns no session found"
+        result instanceof StatementCreationResult.NoSessionExists
+    }
+
+    def "create statement2"() {
+        given:
+        def params = newStatement()
+        def session = newSession(ApplicationState.KILLED)
+        storage.saveApplication(session)
+        backend.getInfo(session) >>  Optional.of( new ApplicationInfo(session.state, session.id))
+
+        when: "creating statement"
+        def result = service.createStatement(session.id, params)
+
+        then: "returns session in invalid state"
+        result instanceof StatementCreationResult.SessionInInvalidState
+        ((StatementCreationResult.SessionInInvalidState)result).getInvalidState() == session.state
+    }
+
+    def "create statement3"() {
+        given:
+        def statementToCreate = newStatement()
+        def session = newSession(ApplicationState.STARTING)
+        storage.saveApplication(session)
+        backend.getInfo(session) >>  Optional.of( new ApplicationInfo(session.state, session.id))
+        def statementCreated = statement()
+        statementHandler.processStatement(session.id, statementToCreate) >> statementCreated
+
+        when: "creating statement"
+        def result = service.createStatement(session.id, statementToCreate)
+
+        then: "returns statement created"
+        result instanceof StatementCreationResult.StatementCreated
+        ((StatementCreationResult.StatementCreated)result).getStatement() == statementCreated
+    }
+
 }

--- a/server/src/test/groovy/com/exacaster/lighter/test/Factories.groovy
+++ b/server/src/test/groovy/com/exacaster/lighter/test/Factories.groovy
@@ -39,7 +39,7 @@ class Factories {
     static newSession(state = ApplicationState.NOT_STARTED) {
         ApplicationBuilder.builder().setAppId("application_123_0124")
                 .setType(ApplicationType.SESSION)
-                .setState(ApplicationState.NOT_STARTED)
+                .setState(state)
                 .setAppInfo("info")
                 .setCreatedAt(LocalDateTime.MAX)
                 .setId("2")
@@ -70,5 +70,9 @@ class Factories {
                 ["spark.kubernetes.driverEnv.TEST": "test"],
                 ["spark.kubernetes.driverEnv.TEST": "test"]
         )
+    }
+
+    static newStatement() {
+        new Statement(null, "code", null, null, LocalDateTime.now())
     }
 }


### PR DESCRIPTION
Fixing https://github.com/exacaster/lighter/issues/709

Note on implementation:
As of now `createStatement` can return one of 3 possible options:
- success (so statement is created)
- no session (in case one wants to create a statement for non existing session)
- statement shall not be created as session is "completed" 

To model a function/method which can return one of these 3 options (with each of them having complete different shape) i see/know following approaches:
- using multiple exceptions: i do not like this approach as it is controlling a flow with exceptions. Beside, these 3 cases are not exceptions, they are just regular sunny/rainy-day outputs. 
- using one common, super set class which can host all data of these 3 options: code is very nasty with if/else (as at some point i need to figure out what option is actually retuned and act accordingly), super-set class is often very low-coherent
- using algebraic data types with pattern matching- it is IMHO the best approach, but it is not available out-of box in "old" java 

I decided to go for option 3 but as we are in old java, without kotlin/scala the implementation is pretty exotic as it is based on visitor pattern, ie I return `StatementCreationResult` which can be visited with `StatementCreationResultMapper`. Both are abstractions and the overall solution provides:
- exhaustive type checking (by using visitor), so in case code needs to be extended i will provide a new implementation of `StatementCreationResult` which would force me to update `StatementCreationResultMapper`.
-  `StatementCreationResultMapper` separates logic from "delivery-mechanism" being micronaut here. So high level policy does not depend on low level policy...

If it were new java/kotlin the code would be much simpler as in controller i would do sth like:

```
sealed interface StatementCreationResult

class StatementCreated(statement: Statement) : StatementCreationResult
object NoSessionExists : StatementCreationResult
class SessionInInvalidState(invalidState: ApplicationState) : StatementCreationResult 
```
and in controller

```
val result = sessionService.createStatement(id, statement)
when(result) {
is NoSessionExists ->  HttpResponse.notFound()
is SessionInInvalidState -> HttpResponse.badRequest("invalid session state " + invalidState);
is StatementCreated ->  HttpResponse.created(statement);
}
```

Compiler will force me to handle all possible options in when statement and the code will be more straightforward 

