### PR TITLE
Return Optional.empty() instead of rethrowing exception and catch RuntimeException when submiting

### DIFF
--- a/server/src/main/java/com/exacaster/lighter/backend/yarn/YarnBackend.java
+++ b/server/src/main/java/com/exacaster/lighter/backend/yarn/YarnBackend.java
@@ -49,8 +49,7 @@ public class YarnBackend implements Backend {
     @Override
     public Optional<ApplicationInfo> getInfo(Application application) {
         return getYarnApplicationId(application)
-                .flatMap(id -> getState(id).map(state -> new ApplicationInfo(state, id)))
-            .or(() -> Optional.of(new ApplicationInfo(ApplicationState.DEAD, null)));
+                .flatMap(id -> getState(id).map(state -> new ApplicationInfo(state, id)));
     }
 
     private Optional<ApplicationState> getState(String id) {
@@ -144,7 +143,7 @@ public class YarnBackend implements Backend {
                                 .max(Comparator.comparing(ApplicationReport::getStartTime))
                                 .map(ApplicationReport::getApplicationId)
                                 .map(ApplicationId::toString);
-                    } catch (YarnException | IOException e) {
+                    } catch (YarnException | IOException | RuntimeException e) {
                         LOG.error("Failed to get app id for app: {}", application, e);
                         return Optional.empty();
                     }

--- a/server/src/main/java/com/exacaster/lighter/backend/yarn/YarnBackend.java
+++ b/server/src/main/java/com/exacaster/lighter/backend/yarn/YarnBackend.java
@@ -49,7 +49,8 @@ public class YarnBackend implements Backend {
     @Override
     public Optional<ApplicationInfo> getInfo(Application application) {
         return getYarnApplicationId(application)
-                .flatMap(id -> getState(id).map(state -> new ApplicationInfo(state, id)));
+                .flatMap(id -> getState(id).map(state -> new ApplicationInfo(state, id)))
+            .or(() -> Optional.of(new ApplicationInfo(ApplicationState.DEAD, null)));
     }
 
     private Optional<ApplicationState> getState(String id) {
@@ -145,7 +146,7 @@ public class YarnBackend implements Backend {
                                 .map(ApplicationId::toString);
                     } catch (YarnException | IOException e) {
                         LOG.error("Failed to get app id for app: {}", application, e);
-                        throw new IllegalStateException(e);
+                        return Optional.empty();
                     }
                 });
     }

--- a/server/src/main/java/com/exacaster/lighter/backend/yarn/YarnBackend.java
+++ b/server/src/main/java/com/exacaster/lighter/backend/yarn/YarnBackend.java
@@ -149,12 +149,11 @@ public class YarnBackend implements Backend {
                     } catch (RuntimeException e) {
                         // Yarn client sometimes throws IOException wrapped in RuntimeException
                         LOG.error("Failed to get app id for app: {}", application, e);
-                        String message = e.getMessage();
-                        if (message != null && message.contains("java.io.IOException")) {
+                        if (e.getCause() instanceof IOException) {
                             return Optional.empty();
-                        } else {
-                            throw e;
                         }
+
+                        throw e;
                     }
                 });
     }

--- a/server/src/test/groovy/com/exacaster/lighter/backend/yarn/YarnBackendTest.groovy
+++ b/server/src/test/groovy/com/exacaster/lighter/backend/yarn/YarnBackendTest.groovy
@@ -49,17 +49,16 @@ class YarnBackendTest extends Specification {
         info.state == ApplicationState.BUSY
     }
 
-    def "gets app info with DEAD state if IOException thrown"() {
+    def "gets empty app info if IOException thrown"() {
         given:
         def app = newApplication(null)
 
         when:
-        def info = backend.getInfo(app).get()
+        def info = backend.getInfo(app)
 
         then:
         1 * client.getApplications(*_) >> { throw new IOException() }
-        info.getApplicationId() == null
-        info.getState() == ApplicationState.DEAD
+        info.isEmpty()
     }
 
 

--- a/server/src/test/groovy/com/exacaster/lighter/backend/yarn/YarnBackendTest.groovy
+++ b/server/src/test/groovy/com/exacaster/lighter/backend/yarn/YarnBackendTest.groovy
@@ -61,6 +61,17 @@ class YarnBackendTest extends Specification {
         info.isEmpty()
     }
 
+    def "gets empty app info if RuntimeException with IOException thrown"() {
+        given:
+        def app = newApplication(null)
+
+        when:
+        def info = backend.getInfo(app)
+
+        then:
+        1 * client.getApplications(*_) >> { throw new RuntimeException("java.lang.RuntimeException: Exception in thread \"main\" java.io.IOException: Could not get block locations") }
+        info.isEmpty()
+    }
 
     def "fetches logs"() {
         given:

--- a/server/src/test/groovy/com/exacaster/lighter/backend/yarn/YarnBackendTest.groovy
+++ b/server/src/test/groovy/com/exacaster/lighter/backend/yarn/YarnBackendTest.groovy
@@ -49,6 +49,19 @@ class YarnBackendTest extends Specification {
         info.state == ApplicationState.BUSY
     }
 
+    def "gets app info with DEAD state if IOException thrown"() {
+        given:
+        def app = newApplication(null)
+
+        when:
+        def info = backend.getInfo(app).get()
+
+        then:
+        1 * client.getApplications(*_) >> { throw new IOException() }
+        info.getApplicationId() == null
+        info.getState() == ApplicationState.DEAD
+    }
+
 
     def "fetches logs"() {
         given:
@@ -104,4 +117,5 @@ class YarnBackendTest extends Specification {
         client.getApplications(*_) >> [yarnApp]
         client.getApplicationReport(yarnId) >> yarnApp
     }
+
 }

--- a/server/src/test/groovy/com/exacaster/lighter/backend/yarn/YarnBackendTest.groovy
+++ b/server/src/test/groovy/com/exacaster/lighter/backend/yarn/YarnBackendTest.groovy
@@ -69,7 +69,7 @@ class YarnBackendTest extends Specification {
         def info = backend.getInfo(app)
 
         then:
-        1 * client.getApplications(*_) >> { throw new RuntimeException("java.lang.RuntimeException: Exception in thread \"main\" java.io.IOException: Could not get block locations") }
+        1 * client.getApplications(*_) >> { throw new RuntimeException(new IOException("test")) }
         info.isEmpty()
     }
 


### PR DESCRIPTION
At the moment we are rethrowing the exception in cases there were issues in getting Application ID from the YarnBackend. We should instead return optional empty and just log the exception in order to allow calling code to decide what to do if application Id could not be fetched.

Also we need to add RuntimeException which is thrown sometimes by Hadoop/Spark libs:
```
java.lang.RuntimeException: Exception in thread "main" java.io.IOException: Could not get block locations. Source file "/user/xxxxx/.sparkStaging/application_1698161930067_305157/xxxxx" - Aborting...block==null
        at org.apache.spark.launcher.OutputRedirector.redirect(OutputRedirector.java:67)
        at java.base/java.lang.Thread.run(Unknown Source)
...
```