### PR TITLE
support arm64, setup-node@v4 to fix yarn download issue

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
       - name: Cache Dependencies

--- a/.github/workflows/publish-registry-pr.yml
+++ b/.github/workflows/publish-registry-pr.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           build-args: |
             SPARK_VERSION=${{ matrix.spark_version }}
             HADOOP_VERSION=${{ matrix.hadoop_version }}

--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: docker/build-push-action@v3
         with:
           push: true
+          platforms: linux/amd64,linux/arm64
           build-args: |
             SPARK_VERSION=${{ matrix.spark_version }}
             HADOOP_VERSION=${{ matrix.hadoop_version }}


### PR DESCRIPTION
I tested lighter on arm64, above are extra option to get the docker compatible with both arm64 and amd64.  

I already tested it on arm64 docker engine and it works

Let me know if you need more clarification. 

