### PR TITLE
Fix statement cancelled statement status

### DIFF
--- a/frontend/src/client/types.ts
+++ b/frontend/src/client/types.ts
@@ -42,7 +42,7 @@ export type SessionStatementCode = {
 
 export type SessionStatement = SessionStatementCode & {
   id: string;
-  state: 'available' | 'error' | 'waiting' | 'canceled';
+  state: 'available' | 'error' | 'waiting' | 'cancelled';
   output?: {
     status: 'ok' | 'error';
     traceback?: string;

--- a/frontend/src/components/statement/Statement.tsx
+++ b/frontend/src/components/statement/Statement.tsx
@@ -14,7 +14,7 @@ const Statement: React.FC<{sessionId: string; statement: SessionStatement}> = ({
     switch (statement.state) {
       case 'available':
         return <FaCheck color="green" />;
-      case 'canceled':
+      case 'cancelled':
         return <FaStop />;
       case 'error':
         return <RiErrorWarningFill color="red" />;
@@ -35,7 +35,7 @@ const Statement: React.FC<{sessionId: string; statement: SessionStatement}> = ({
             <Box>
               <VStack>
                 {statusIcon}
-                {statement.state !== 'canceled' ? (
+                {statement.state !== 'cancelled' ? (
                   <IconButton variant="ghost" onClick={() => cancel()} loading={isCanceling} aria-label="Cancel">
                     <FaStop />
                   </IconButton>

--- a/server/src/main/java/com/exacaster/lighter/application/sessions/processors/StatementHandler.java
+++ b/server/src/main/java/com/exacaster/lighter/application/sessions/processors/StatementHandler.java
@@ -8,6 +8,7 @@ public interface StatementHandler {
     Statement processStatement(String id, Statement statement);
     Statement getStatement(String id, String statementId);
     Optional<Statement> cancelStatement(String id, String statementId);
+    void cancelStatements(String id);
 
     boolean hasWaitingStatement(Application application);
 }

--- a/server/src/main/java/com/exacaster/lighter/application/sessions/processors/python/PythonSessionIntegration.java
+++ b/server/src/main/java/com/exacaster/lighter/application/sessions/processors/python/PythonSessionIntegration.java
@@ -16,6 +16,8 @@ import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
+import jakarta.transaction.Transactional;
 import org.slf4j.Logger;
 import py4j.GatewayServer;
 
@@ -80,7 +82,15 @@ public class PythonSessionIntegration implements StatementHandler {
 
     @Override
     public Optional<Statement> cancelStatement(String id, String statementId) {
-        return statementStorage.updateState(id, statementId, "canceled");
+        return statementStorage.updateState(id, statementId, "cancelled");
+    }
+
+    @Transactional
+    @Override
+    public void cancelStatements(String id) {
+        statementStorage.findByState(id, "waiting").forEach(statement -> {
+            cancelStatement(id, statement.getId());
+        });
     }
 
     @EventListener

--- a/server/src/main/java/com/exacaster/lighter/rest/exceptions/InvalidSessionStateExceptionHandler.java
+++ b/server/src/main/java/com/exacaster/lighter/rest/exceptions/InvalidSessionStateExceptionHandler.java
@@ -12,7 +12,6 @@ import io.micronaut.http.server.exceptions.response.ErrorResponseProcessor;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
-import java.util.List;
 import java.util.Map;
 
 @Produces

--- a/server/src/main/resources/db/migration/V7__update_statement_cancelled.sql
+++ b/server/src/main/resources/db/migration/V7__update_statement_cancelled.sql
@@ -1,0 +1,1 @@
+update application_statement set state='cancelled' where state='canceled';

--- a/server/src/test/groovy/com/exacaster/lighter/application/sessions/SessionHandlerTest.groovy
+++ b/server/src/test/groovy/com/exacaster/lighter/application/sessions/SessionHandlerTest.groovy
@@ -85,9 +85,9 @@ class SessionHandlerTest extends Specification {
         handler.trackRunning()
 
         then:
-        1 * tracker.processApplicationRunning(session, _)
-        1 * tracker.processApplicationRunning(session2, _)
-        1 * tracker.processApplicationRunning(permanentSession, _)
+        1 * tracker.processApplicationRunning(session, _) >> ApplicationState.BUSY
+        1 * tracker.processApplicationRunning(session2, _) >> ApplicationState.BUSY
+        1 * tracker.processApplicationRunning(permanentSession, _) >> ApplicationState.BUSY
     }
 
     def app() {


### PR DESCRIPTION
- We had `canceled` status for Session statements, while Livy API uses `cancelled` - https://livy.incubator.apache.org/docs/latest/rest-api.html#statement
 Due to API missmatch Sparkmagic never detected cancelled state, and Statement was treated as running forever.
 
 - Also when session got killed/dead its waiting statements were kept in `waiting` state. Because of that, Sparkmagic kernel assumed that the last running statement is running forever.
