### PR TITLE
Update Dockerfile - SPARK_VERSION to 3.5.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:17-jdk-jammy AS server
 
-ARG SPARK_VERSION=3.5.4
+ARG SPARK_VERSION=3.5.5
 ARG HADOOP_VERSION=3
 
 WORKDIR /home/app/
@@ -11,7 +11,7 @@ RUN ./gradlew build -x test -PSPARK_VERSION=${SPARK_VERSION}
 
 FROM node:lts-alpine3.18 AS frontend
 
-ARG SPARK_VERSION=3.5.4
+ARG SPARK_VERSION=3.5.5
 ARG HADOOP_VERSION=3
 
 ENV APP_BASE_URL='/lighter'
@@ -25,7 +25,7 @@ RUN yarn install && yarn build
 
 FROM eclipse-temurin:17-jre-jammy
 
-ARG SPARK_VERSION=3.5.4
+ARG SPARK_VERSION=3.5.5
 ARG HADOOP_VERSION=3
 
 ENV FRONTEND_PATH=/home/app/frontend/


### PR DESCRIPTION
Updating the Spark version in the Dockerfile to the current version available to download.
![image](https://github.com/user-attachments/assets/e175059d-10d4-4b36-ab87-eb66a13affb4)

Before I was experiencing the following error during the docker image building:
![image](https://github.com/user-attachments/assets/cd175e2f-1e83-4b37-a8e8-84c85897641e)
