### PR TITLE
fix missing time import in shell_wrapper.py

### DIFF
--- a/server/src/main/resources/shell_wrapper.py
+++ b/server/src/main/resources/shell_wrapper.py
@@ -5,6 +5,7 @@ import ast
 import traceback
 import os
 import logging
+import time
 sys_stdin = sys.stdin
 sys_stdout = sys.stdout
 


### PR DESCRIPTION
Missed the time import in https://github.com/exacaster/lighter/pull/1360